### PR TITLE
docs: move table of content after main README and remove duplicated h1

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,3 @@
-# Welcome to Django prodserver documentation!
-
 ```{include} ../README.md
 
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,9 @@
 # Welcome to Django prodserver documentation!
 
+```{include} ../README.md
+
+```
+
 ```{toctree}
 :caption: Installation & Usage
 :maxdepth: 2
@@ -22,8 +26,4 @@ contributing
 :maxdepth: 2
 
 django_prodserver
-```
-
-```{include} ../README.md
-
 ```


### PR DESCRIPTION
### Description of change

<img width="1626" height="945" alt="image" src="https://github.com/user-attachments/assets/7ab6ed52-69e6-48d3-ad74-a17d695ae9d6" />

the homepage of the docs start with the table of content which is a bit overwhelming. A more appropriate order would be to have the main README first. Also the "Welcome to..." at the top and the big "Django prodserver" are both `h1` tag which is not ideal.

That's something I discovered recently in my package template 🤦🏻 so porting the fix here.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/nanorepublica/django-prodserver/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".
