### PR TITLE
feat: add backend for Celery beat process

### DIFF
--- a/src/django_prodserver/backends/celery.py
+++ b/src/django_prodserver/backends/celery.py
@@ -16,3 +16,11 @@ class CeleryWorker(BaseServerBackend):
     def start_server(self, *args: str) -> None:
         """Start Celery Worker."""
         self.app.Worker(*args).start()
+
+
+class CeleryBeat(CeleryWorker):
+    """Backend to start a celery beat process."""
+
+    def start_server(self, *args: str) -> None:
+        """Start Celery beat."""
+        self.app.Beat(*args).start()


### PR DESCRIPTION
### Description of change

While trying to use django-prodserver, I got stuck when trying to run the beat process and noticed that it wasn't supported yet, so adding a backend for it.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/nanorepublica/django-prodserver/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
