### PR TITLE
fix(backend): allow passing arguments without values

### DIFF
--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -76,6 +76,7 @@ PRODUCTION_PROCESSES = {
         "ARGS": {
             "bind": "0.0.0.0:8000",
             "workers": "2",
+            "preload": None,
         }
     }
 }
@@ -87,6 +88,7 @@ PRODUCTION_PROCESSES = {
 - Uses Gunicorn as the server backend
 - Binds to all interfaces (0.0.0.0) on port 8000
 - Runs with 2 worker processes for handling concurrent requests
+- Preloads your wsgi app
 
 ## Step 4: Run Your Production Server
 

--- a/src/django_prodserver/backends/base.py
+++ b/src/django_prodserver/backends/base.py
@@ -42,16 +42,24 @@ class BaseServerBackend:
         This function transforms the dictionary settings configuration
         from:
             {
-                "bind": "0.0.0.0:8111"
+                "bind": "0.0.0.0:8111",
+                "preload": None,
             }
         to
             [
-                "--bind=0.0.0.0:8111"
+                "--bind=0.0.0.0:8111",
+                "--preload",
             ]
         """
         if isinstance(args, str):
             return [args]
-        return [f"--{arg_name}={arg_value}" for arg_name, arg_value in args.items()]
+
+        def format_arg(arg_name, arg_value):
+            if arg_value is None:
+                return f"--{arg_name}"
+            return f"--{arg_name}={arg_value}"
+
+        return [format_arg(arg_name, arg_value) for arg_name, arg_value in args.items()]
 
     # def run_from_argv(self, argv):
     # TODO: The below should be looked into and implemented

--- a/tests/backends/test_base.py
+++ b/tests/backends/test_base.py
@@ -43,9 +43,9 @@ def test_prep_server_args_empty():
 def test_format_server_args_from_dict():
     """Test _format_server_args_from_dict method."""
     backend = BaseServerBackend()
-    args = {"bind": "0.0.0.0:8000", "workers": "4"}
+    args = {"bind": "0.0.0.0:8000", "workers": "4", "preload": None}
     result = backend._format_server_args_from_dict(args)
-    assert result == ["--bind=0.0.0.0:8000", "--workers=4"]
+    assert result == ["--bind=0.0.0.0:8000", "--workers=4", "--preload"]
 
 
 def test_format_server_args_from_empty_dict():


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/nanorepublica/django-prodserver/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

Fixes #95 

Support passing arguments that do not take a value like `--preload`
<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/nanorepublica/django-prodserver/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
