### PR TITLE
Allow "default" key in PRODUCTION_PROCESSES to start prodserver without an argument name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -140,3 +140,4 @@ dmypy.json
 cython_debug/
 # Generated file
 requirements-dev.txt
+.DS_Store

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,32 @@ python manage.py prodserver <process_name>
 
 ## Common Patterns
 
+### Default Process
+
+Name a process `"default"` to make it run when no argument is given:
+
+```python
+PRODUCTION_PROCESSES = {
+    "default": {
+        "BACKEND": "django_prodserver.backends.gunicorn.GunicornServer",
+        "ARGS": {"bind": "0.0.0.0:8000", "workers": "4"},
+    },
+    "worker": {
+        "BACKEND": "django_prodserver.backends.celery.CeleryWorker",
+        "APP": "myproject.celery.app",
+        "ARGS": {"concurrency": "4"},
+    },
+}
+```
+
+```bash
+python manage.py prodserver          # starts "default"
+python manage.py prodserver default  # equivalent
+python manage.py prodserver worker   # starts worker
+```
+
+If no `"default"` key exists, a process name argument is required.
+
 ### Single Web Server
 
 ```python

--- a/src/django_prodserver/management/commands/prodserver.py
+++ b/src/django_prodserver/management/commands/prodserver.py
@@ -21,13 +21,12 @@ class Command(BaseCommand):
                 "PRODUCTION_PROCESSES setting has been configured incorrectly.\n"
                 "Check the documentation to configure this setting correctly."
             ) from None
-        try:
-            default = next(iter(choices))
-        except StopIteration:
+        if not choices:
             raise CommandError(
                 "No servers configured in the PRODUCTION_PROCESSES setting.\n"
                 "Configure your servers before running this command."
-            ) from None
+            )
+        default = "default" if "default" in choices else None
         parser.add_argument(
             "server_name",
             type=str,
@@ -77,6 +76,14 @@ class Command(BaseCommand):
         self, server_name: str, *args: list[str], **kwargs: Mapping[str, str]
     ) -> None:
         """Start the correct process based on the provided name."""
+        if server_name is None:
+            available_servers = "\n ".join(app_settings.PRODUCTION_PROCESSES.keys())
+            raise CommandError(
+                "No process name provided and no 'default' process configured.\n"
+                f"Available names are:\n {available_servers}\n\n"
+                "Hint: Add a 'default' key to PRODUCTION_PROCESSES to allow "
+                "running prodserver without arguments."
+            )
         # this try/except could be removed, keeping for now as it's a nicer
         try:
             server_config = app_settings.PRODUCTION_PROCESSES[server_name]

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -53,6 +53,10 @@ TEMPLATES = [
 ]
 
 PRODUCTION_PROCESSES = {
+    "default": {
+        "BACKEND": "django_prodserver.backends.gunicorn.GunicornServer",
+        "ARGS": {"bind": "0.0.0.0:8222", "workers": "2"},
+    },
     "web-g": {
         "BACKEND": "django_prodserver.backends.gunicorn.GunicornServer",
         "ARGS": {"bind": "0.0.0.0:8222", "workers": "2"},

--- a/tests/test_prodserver_command.py
+++ b/tests/test_prodserver_command.py
@@ -331,8 +331,8 @@ class TestProdserverCommand(TestCase):
             "worker": {"BACKEND": "django_prodserver.backends.celery.CeleryWorker"},
         }
     )
-    def test_default_server_selection(self):
-        """Test that first server is selected as default."""
+    def test_no_default_key_means_no_default(self):
+        """Test that without a 'default' key, default is None."""
         parser = MagicMock()
         self.command.add_arguments(parser)
 
@@ -340,10 +340,23 @@ class TestProdserverCommand(TestCase):
         server_name_call = calls[0]
         args, kwargs = server_name_call
 
-        # Should have a default value (first in choices)
-        assert "default" in kwargs
-        # The default should be one of the available choices
-        assert kwargs["default"] in kwargs["choices"]
+        assert kwargs["default"] is None
+
+    @override_settings(
+        PRODUCTION_PROCESSES={
+            "web": {"BACKEND": "django_prodserver.backends.gunicorn.GunicornServer"},
+            "worker": {"BACKEND": "django_prodserver.backends.celery.CeleryWorker"},
+        }
+    )
+    @patch("sys.exit")
+    def test_no_arg_without_default_key_errors(self, mock_exit):
+        """Test that running without an argument and no 'default' key raises an error."""
+        self.command.run_from_argv(["manage.py", "prodserver"])
+
+        error_output = self.command.stderr.getvalue()
+        assert "No process name provided" in error_output
+        assert "default" in error_output
+        mock_exit.assert_called_with(1)
 
     @override_settings(
         PRODUCTION_PROCESSES={
@@ -462,6 +475,49 @@ class TestProdserverCommand(TestCase):
         """Test that command has appropriate help text."""
         # The command should have help text accessible
         assert hasattr(self.command, "help")
+
+    @override_settings(
+        PRODUCTION_PROCESSES={
+            "web": {"BACKEND": "django_prodserver.backends.gunicorn.GunicornServer"},
+            "default": {
+                "BACKEND": "django_prodserver.backends.uvicorn.UvicornServer"
+            },
+            "worker": {"BACKEND": "django_prodserver.backends.celery.CeleryWorker"},
+        }
+    )
+    def test_default_key_used_as_default(self):
+        """Test that 'default' key is preferred as the default server."""
+        parser = MagicMock()
+        self.command.add_arguments(parser)
+
+        calls = parser.add_argument.call_args_list
+        server_name_call = calls[0]
+        args, kwargs = server_name_call
+        assert kwargs["default"] == "default"
+        assert "default" in kwargs["choices"]
+
+    @override_settings(
+        PRODUCTION_PROCESSES={
+            "default": {
+                "BACKEND": "django_prodserver.backends.gunicorn.GunicornServer"
+            },
+        }
+    )
+    @patch("django_prodserver.management.commands.prodserver.import_string")
+    def test_run_from_argv_no_arg_uses_default_key(self, mock_import_string):
+        """Test that running without an argument starts the 'default' process."""
+        mock_backend_class = Mock()
+        mock_backend_instance = Mock()
+        mock_backend_instance.prep_server_args.return_value = []
+        mock_backend_class.return_value = mock_backend_instance
+        mock_import_string.return_value = mock_backend_class
+
+        self.command.run_from_argv(["manage.py", "prodserver"])
+
+        mock_import_string.assert_called_once_with(
+            "django_prodserver.backends.gunicorn.GunicornServer"
+        )
+        mock_backend_instance.start_server.assert_called_once()
 
     @override_settings(PRODUCTION_PROCESSES={})
     def test_add_arguments_no_servers_configured(self):


### PR DESCRIPTION
# fixes #92 in part

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/nanorepublica/django-prodserver/blob/main/CONTRIBUTING.md).
- [x] This pull request links relevant issues as `Fixes #0000`
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".


