### PR TITLE
docs: add Phase 0 and parent split-package specifications

### DIFF
--- a/agent-os/specs/2026-05-11-split-package-into-multiple-repos/planning/raw-idea.md
+++ b/agent-os/specs/2026-05-11-split-package-into-multiple-repos/planning/raw-idea.md
@@ -1,0 +1,15 @@
+# Raw Idea
+
+> Captured from conversation on 2026-05-11.
+
+I would like to explore what it would look like to split the package into multiple
+repos. The purpose here is to have a **core package** with the goal of eventually
+being **merged into Django** with some of the backends, while other backends would
+ideally be **merged into their respective upstream repos** (gunicorn, uvicorn,
+django-tasks, django-q2, celery, ...) or **sit in a separate repo** that lets a
+developer opt in to them.
+
+Implementation note from the requester: each structural option should be explored
+on its own branch so the trade-offs can be compared with real code, not just on
+paper. This spec is therefore written as a set of parallel exploration tracks
+rather than a single linear plan.

--- a/agent-os/specs/2026-05-11-split-package-into-multiple-repos/spec.md
+++ b/agent-os/specs/2026-05-11-split-package-into-multiple-repos/spec.md
@@ -6,6 +6,20 @@ Exploratory spec. The goal of this spec is to **evaluate** structural options by
 prototyping each on its own branch, then pick one. It is intentionally written as
 parallel exploration tracks rather than a single linear implementation plan.
 
+## Related Issues
+
+- [#98](https://github.com/nanorepublica/django-prodserver/issues/98) —
+  "Splitting out the backends and the core API". This is the parent issue this
+  spec addresses: explore a future where the core API + commands can be merged
+  into Django, with each backend ideally merged into its individual upstream
+  project, and (as an immediate step) break the backends out into their own
+  package(s). Raised by Jake at DjangoCon Europe.
+- [#71](https://github.com/nanorepublica/django-prodserver/issues/71) —
+  "Entrypoint support for backends". Directly satisfied by the shared
+  prerequisite below; requested so external packages (e.g. Chancy) can register
+  backends without end-user setup. Useful on its own even if the package is
+  never split.
+
 ## Goal
 
 Restructure django-prodserver so that:
@@ -50,10 +64,9 @@ actually depends on the adapters being in the same distribution — `import_stri
 in `server.py:99` will happily import a backend class from any installed package.
 That is what makes the split feasible.
 
-This work is also aligned with roadmap items **#71 "Entrypoint support for
-backends"** and **#20 "plugin system for third-party backends"** — the plugin
-discovery mechanism described below is a hard prerequisite for any of the split
-options, and is useful on its own even if the repo is never split.
+See the **Related Issues** section above for the GitHub issues this spec
+addresses (#98 is the driver; #71 is satisfied as a side-effect of the shared
+prerequisite).
 
 ## Non-Goals / Out of Scope
 

--- a/agent-os/specs/2026-05-11-split-package-into-multiple-repos/spec.md
+++ b/agent-os/specs/2026-05-11-split-package-into-multiple-repos/spec.md
@@ -82,10 +82,25 @@ prerequisite).
 - Publishing anything to PyPI as part of the spike — prototypes can be built and
   installed locally / from git, but actual releases are a separate decision.
 
-## Shared Prerequisite (applies to every option)
+## Phase 0 — Prerequisite (do this first, regardless of which split wins)
 
-Before any repo/package split, land these on a base branch that all option
-branches fork from. None of this is breaking.
+This was previously framed as "Option C" alongside A and B. It is **not** an
+exploration track — it's a hard prerequisite that lands on its own branch and
+merges to `main` before any of the split-option branches are started. The split
+branches then fork from this work.
+
+Phase 0 is independently valuable: even if no further split ever happens, it
+delivers the entry-point contract requested in #71 (so external packages can
+register backends) and makes the core's dependency surface explicit.
+
+**Branch:** `claude/prodserver-entrypoint-foundation`
+
+**Scope is non-breaking:**
+
+- `PRODUCTION_PROCESSES["<name>"]["BACKEND"] = "django_prodserver.backends.gunicorn.GunicornServer"`
+  keeps working.
+- `pip install django-prodserver[gunicorn]` keeps working.
+- All current tests stay green; no adapter modules move yet.
 
 ### P1. Entry-point–based backend discovery
 
@@ -132,11 +147,32 @@ branches fork from. None of this is breaking.
 - Provide a `tox`/CI matrix story for "core only" vs "core + one adapter" vs
   "everything" so a contributor can run the slice they care about.
 
-## Options To Explore (one branch each)
+### P4. Document the plugin contract
+
+- Add `docs/extending.md` (or equivalent) describing the entry-point group,
+  what `BaseServerBackend` requires, and the satellite-package naming convention
+  decided in P2.
+- Add a tiny example out-of-tree adapter under `examples/` that registers itself
+  via entry points and is exercised in CI as smoke proof that the contract works.
+
+### Phase 0 done criteria
+
+- Entry-point registry lands; both short names and dotted paths resolve.
+- All existing tests green; no public-API breakage.
+- Core import graph contains no third-party deps beyond `django`
+  (assert this with a test).
+- `docs/extending.md` published; example adapter installs and runs in CI.
+- Branch is merged to `main`. All option branches below fork from it.
+
+## Split Options To Explore (one branch each, after Phase 0)
 
 Each option below should be prototyped far enough to answer the **decision
-criteria** at the bottom. Suggested branch names are given; the requester will
+criteria** further down. Suggested branch names are given; the requester will
 create/drive these branches.
+
+Note: the *packaging strategy* (next section) is an orthogonal axis — every
+option here should be tried under at least one packaging strategy, and ideally
+its preferred one.
 
 ### Option A — Full multi-repo
 
@@ -206,26 +242,85 @@ their own repos later (Option A) if an upstream bites.
 needs care (semantic-release config currently assumes one package); "merged into
 respective upstream repos" still requires a later move.
 
-### Option C — Single package, plugin-ready, no split (the "do less" option)
+> Option C from the previous draft ("single package, plugin-ready, no split") is
+> not an option anymore — that work is **Phase 0** above and happens regardless.
 
-**Branch:** `claude/split-plugin-only-spike`
+## Packaging Strategy (orthogonal to Option A vs B)
 
-- Land only the Shared Prerequisite (entry points + boundary cleanup + test
-  federation), keep shipping one `django-prodserver` distribution with the
-  current extras.
-- The payoff: third parties (including the upstream projects, if they want) can
-  publish their *own* adapter packages against the documented entry-point
-  contract, without us splitting anything. The "core" is already importable on
-  its own; we just document the subset that would go to Django.
-- Deliverables on the branch: the P1–P3 work, a `docs/extending.md` describing
-  the backend plugin contract and entry-point group, and an example out-of-tree
-  adapter package in `examples/` to prove the contract works.
+The repo-layout decision (A vs B) is independent from the *install UX* decision.
+The same code split can be shipped to PyPI in two distinct shapes, and the
+trade-offs are different enough that each split option's branch should pick one
+explicitly. These strategies are what determines what a user types when they
+install.
 
-**Pros:** smallest change, no release/CI multiplication, unblocks the ecosystem
-goal immediately, fully reversible.
-**Cons:** doesn't by itself achieve "core merged into Django" or "adapters in
-upstream repos" — it just makes both *possible* later. The big adapters
-(werkzeug, daphne, granian) still ship in the main distribution.
+### Strategy 1 — Umbrella extras preserved (recommended default)
+
+The user-facing install command is **unchanged**:
+
+```sh
+pip install django-prodserver[gunicorn]
+```
+
+But under the hood:
+
+- `django-prodserver` becomes a thin **umbrella distribution**. Its
+  `[project.optional-dependencies]` map extras to the satellite adapter
+  packages, not to the upstream server libraries directly:
+  ```toml
+  [project.optional-dependencies]
+  gunicorn = ["django-prodserver-gunicorn"]
+  uvicorn  = ["django-prodserver-uvicorn"]
+  # ...
+  ```
+- `django-prodserver-gunicorn` is the satellite, and it depends on `gunicorn`
+  itself. So the dependency chain resolves to
+  `django-prodserver → django-prodserver-gunicorn → gunicorn`, plus
+  `django-prodserver` pulling in `django-prodserver-core` (the actual core).
+- Existing `PRODUCTION_PROCESSES` dotted paths still resolve, because each
+  satellite ships a thin shim module at the old import path
+  (`django_prodserver.backends.gunicorn`) re-exporting the moved class.
+
+**Pros:** zero-friction migration; existing docs, blog posts, copilot
+suggestions, deployment scripts keep working with no edits; users don't need to
+know the split happened. This is the "same install experience, but installing
+the adapter package instead of the raw server" shape.
+**Cons:** more indirection in the dependency graph (one extra package per
+adapter); umbrella publishing has to be coordinated with adapter publishing
+(can't ship `django-prodserver 4.0` until the satellites it points at exist).
+
+### Strategy 2 — Direct install per package
+
+The user installs each piece explicitly:
+
+```sh
+pip install django-prodserver-core django-prodserver-gunicorn
+```
+
+`django-prodserver` (as a distribution name) is either retired, frozen, or kept
+as a deprecated meta-shim that prints a warning.
+
+**Pros:** cleanest dependency graph; easy to understand which adapter is in use;
+mirrors how `pytest` + `pytest-django` (or `sqlalchemy` + `psycopg2`) is
+typically installed.
+**Cons:** breaks today's install instructions and `[extras]` syntax in every
+existing deployment script and Dockerfile; requires a real deprecation period
+and a migration note; bad first-run UX for users who copy old README snippets.
+
+### Which strategy applies to which option
+
+- **Option A (multi-repo):** can adopt **either** strategy. Strategy 1 needs the
+  umbrella `django-prodserver` to live somewhere — likely this repo, now demoted
+  to "umbrella + core" or split further to "umbrella" vs "core" repos.
+- **Option B (monorepo workspace):** Strategy 1 is the natural fit (umbrella is
+  just another package in the workspace). Strategy 2 is also possible by simply
+  not publishing the umbrella package.
+
+The recommended default for the first spike is **Strategy 1 + Option B**: same
+install UX, no breaking change, split happens behind the extras. Strategy 2
+becomes interesting later if/when adapters get upstreamed into their host
+projects (e.g. gunicorn's repo starts shipping its own `django-prodserver`
+adapter), because then the umbrella's gunicorn extra would point at *that*
+upstream-owned package.
 
 ## Affected / Reference Files
 
@@ -269,10 +364,11 @@ Tests:
 - `tests/backends/*` (federate per P3), `tests/test_server_command.py`,
   `tests/test_conf.py`, `tests/test_utils.py`.
 
-## Decision Criteria (what each branch must let us judge)
+## Decision Criteria (what each option branch must let us judge)
 
 1. **Install ergonomics:** how many `pip install ...` lines does a typical user
-   need, and is the error message good when an adapter dep is missing?
+   need, and is the error message good when an adapter dep is missing? Document
+   under both packaging strategies.
 2. **Maintainer overhead:** number of release pipelines, CI jobs, and changelogs;
    does `semantic-release` still work, or does it need replacing?
 3. **Django-merge readiness:** can the core be built/tested/shipped with only
@@ -284,29 +380,42 @@ Tests:
 5. **Back-compat:** does an existing project with `PRODUCTION_PROCESSES` pointing
    at `django_prodserver.backends.gunicorn.GunicornServer` and
    `pip install django-prodserver[gunicorn]` keep working with no changes?
+   (Strategy 1 should make this trivially yes; Strategy 2 should document the
+   migration path.)
 6. **Reversibility:** how hard is it to undo / re-merge if the experiment fails?
 
 ## Recommendation (to be confirmed after the spikes)
 
-Start by landing the **Shared Prerequisite** (which is Option C in full). Then
-prototype **Option B (monorepo workspace)** as the primary candidate — it
-delivers the per-adapter install/versioning win and the "core is liftable into
-Django" story with the least disruption, while keeping the door open to Option A
-on a per-adapter basis whenever an upstream project agrees to host the adapter.
-Treat **Option A** as the long-term end state for individual adapters, not a
-big-bang migration.
+1. **Land Phase 0 first**, on its own branch and merged to `main`, before any
+   split spike begins. This delivers #71 by itself and is independently shippable.
+2. After Phase 0, prototype **Option B (monorepo workspace) + Strategy 1
+   (umbrella extras)** as the primary candidate — it delivers per-adapter
+   install/versioning + minimal deps + a clean "lift the core into Django" story
+   *without* changing the user-facing install command.
+3. Run a smaller spike for **Option A (multi-repo)** focused on the
+   `git filter-repo` extraction recipe and what an upstream-PR-ready adapter
+   looks like (e.g. a `django-prodserver-django-tasks` aimed at the django-tasks
+   repo). Use this to validate that A is reachable from B on a per-adapter basis.
+4. Treat **Option A** as the long-term end state for individual adapters that
+   upstreams accept — not a big-bang migration.
+5. **Strategy 2 (direct install)** is deferred: revisit once enough adapters
+   live upstream that the umbrella stops adding value.
 
 ## Success Criteria
 
-- A base branch exists with entry-point discovery + boundary cleanup + a
-  federated test plan, with no breaking change to `PRODUCTION_PROCESSES` and all
-  existing tests green.
-- Three exploration branches exist (A, B, C), each with enough working code to
-  answer the decision criteria, plus a short `FINDINGS.md` on each branch.
-- A written comparison (this spec updated, or a follow-up doc) recommending one
-  option, with explicit answers to the six decision criteria.
-- The core package's dependency closure is demonstrably just `django` in
-  whichever option(s) implement a separate core.
+- **Phase 0** is merged to `main`: entry-point discovery + boundary cleanup +
+  test federation + plugin-contract docs, with no breaking change to
+  `PRODUCTION_PROCESSES` and all existing tests green.
+- **Option-B branch** exists with a working uv workspace; `django-prodserver-core`
+  builds with only `django` as a dep; at least two adapter packages
+  (`gunicorn` + one worker) build and install via Strategy 1's umbrella extras;
+  CI runs the federated test matrix from P3.
+- **Option-A branch** exists with a documented `git filter-repo` extraction
+  recipe and at least one extracted adapter working when installed from a
+  sibling directory.
+- Each branch has a short `FINDINGS.md` answering the six decision criteria.
+- A written comparison (this spec updated, or a follow-up doc) names a winner
+  and confirms the packaging strategy.
 - Docs describe the chosen install story and the backend plugin contract.
 
 ## Risks & Mitigations
@@ -315,8 +424,9 @@ big-bang migration.
   package; multi-package publishing needs new config or a different tool.
   *Mitigation:* spike this explicitly on the Option B branch before committing.
 - **Discoverability regression:** users currently find everything via one
-  package + extras. *Mitigation:* keep an umbrella `django-prodserver`
-  distribution that pulls adapters via extras (Options A2 and B).
+  package + extras. *Mitigation:* default to **Packaging Strategy 1** (umbrella
+  extras preserved) under whichever split option wins, so
+  `pip install django-prodserver[gunicorn]` keeps working.
 - **History loss on extraction:** *Mitigation:* use `git filter-repo` (document
   the recipe on the Option A branch) rather than fresh repos.
 - **Upstreams say no:** gunicorn/uvicorn/celery may not want a Django-specific

--- a/agent-os/specs/2026-05-11-split-package-into-multiple-repos/spec.md
+++ b/agent-os/specs/2026-05-11-split-package-into-multiple-repos/spec.md
@@ -1,0 +1,315 @@
+# Specification: Split django-prodserver Into Multiple Repos/Packages
+
+## Status
+
+Exploratory spec. The goal of this spec is to **evaluate** structural options by
+prototyping each on its own branch, then pick one. It is intentionally written as
+parallel exploration tracks rather than a single linear implementation plan.
+
+## Goal
+
+Restructure django-prodserver so that:
+
+1. A small, dependency-free **core** package can stand on its own and be a
+   credible candidate for eventual inclusion in Django itself (via a DEP — Django
+   Enhancement Proposal). The core owns the `server` / `devserver` / `prodserver`
+   management commands, the `PRODUCTION_PROCESSES` setting, the `BaseServerBackend`
+   / `BaseRunserverBackend` contract, and shared helpers.
+2. Each third-party **backend adapter** (gunicorn, uvicorn, granian, waitress,
+   werkzeug/runserver-plus, daphne, celery, django-tasks, django-q2) can live
+   outside the core — ideally upstreamed into the server/worker project it wraps,
+   or failing that in a dedicated satellite package — so users install only the
+   adapters they actually run, and adapter releases track the upstream they
+   depend on rather than the core's release cadence.
+
+## Background & Motivation
+
+The codebase already has a clean internal seam:
+
+- **Core (no third-party deps):**
+  - `src/django_prodserver/management/commands/server.py` (and the `prodserver`
+    alias + `devserver`)
+  - `src/django_prodserver/conf.py` (`AppSettings`, `PRODUCTION_PROCESSES`)
+  - `src/django_prodserver/backends/base.py` (`BaseServerBackend`)
+  - `src/django_prodserver/backends/_runserver_base.py` (`BaseRunserverBackend`)
+  - `src/django_prodserver/backends/django_runserver.py` (wraps Django's own
+    runserver — the only adapter with zero extra dependencies)
+  - `src/django_prodserver/utils.py` (`wsgi_healthcheck`, `wsgi_app_name`,
+    `asgi_app_name`)
+  - `src/django_prodserver/apps.py`
+- **Server adapters (one third-party dep each):** `gunicorn.py`, `uvicorn.py`,
+  `granian.py`, `waitress.py`, `werkzeug.py` (379 lines — by far the largest),
+  `daphne.py`.
+- **Worker adapters (small, ≤72 lines):** `celery.py`, `django_tasks.py`,
+  `django_q2.py`.
+
+Backends are currently discovered by dotted path strings in
+`PRODUCTION_PROCESSES["<name>"]["BACKEND"]` and the optional extras are declared
+in `pyproject.toml` (`[project.optional-dependencies]`). Nothing in the runtime
+actually depends on the adapters being in the same distribution — `import_string`
+in `server.py:99` will happily import a backend class from any installed package.
+That is what makes the split feasible.
+
+This work is also aligned with roadmap items **#71 "Entrypoint support for
+backends"** and **#20 "plugin system for third-party backends"** — the plugin
+discovery mechanism described below is a hard prerequisite for any of the split
+options, and is useful on its own even if the repo is never split.
+
+## Non-Goals / Out of Scope
+
+- Actually submitting a Django DEP or merging anything into Django. This spec only
+  makes the core *shaped like* a merge candidate.
+- Actually opening PRs against gunicorn / uvicorn / django-tasks / django-q2 /
+  celery. We will document which adapters are upstream-PR candidates and what the
+  integration surface would be, but coordinating those merges is follow-up work.
+- Changing the public configuration format in a breaking way. `PRODUCTION_PROCESSES`
+  with dotted-path `BACKEND` strings must keep working unchanged.
+- Renaming the management commands (tracked separately as #63 / #64).
+- Adding new backends (Celery Flower #88, etc.).
+- Publishing anything to PyPI as part of the spike — prototypes can be built and
+  installed locally / from git, but actual releases are a separate decision.
+
+## Shared Prerequisite (applies to every option)
+
+Before any repo/package split, land these on a base branch that all option
+branches fork from. None of this is breaking.
+
+### P1. Entry-point–based backend discovery
+
+- Define an `importlib.metadata` entry-point group, e.g.
+  `django_prodserver.backends`. Each adapter package registers its backend
+  classes there, e.g.:
+  ```toml
+  [project.entry-points."django_prodserver.backends"]
+  gunicorn = "django_prodserver_gunicorn:GunicornServer"
+  ```
+- In the core, build a registry that:
+  - Collects entry points lazily (on first `server` invocation).
+  - Lets `PRODUCTION_PROCESSES[...]["BACKEND"]` accept **either** a registered
+    short name **or** a dotted path (back-compat). Short name wins only if it
+    resolves; otherwise fall back to `import_string`.
+  - Surfaces a friendly error when a backend name maps to a package that isn't
+    installed (e.g. "backend 'gunicorn' requires the `django-prodserver-gunicorn`
+    package — `pip install django-prodserver-gunicorn`").
+- Update `server --list` (and ideally a new `server --list-backends`) to show
+  registered backends and whether their dependency is importable.
+
+### P2. Package-boundary cleanup in the current tree
+
+- Make `utils.py` import-safe without any optional dep (it already is — only
+  imports Django).
+- Confirm no core module imports an adapter module at import time (currently
+  true; lock it in with a test).
+- Ensure each adapter module's heavy import (`import gunicorn`, `import granian`,
+  ...) happens inside `start_server` / `__init__`, not at module top level, so
+  the registry can reference the class without the dep installed. (Audit each
+  adapter; several already do this.)
+- Decide the import name / distribution name convention for satellites:
+  - Distribution: `django-prodserver-<name>` (e.g. `django-prodserver-gunicorn`).
+  - Import package: `django_prodserver_<name>` **or** a PEP 420 namespace
+    package `django_prodserver.contrib.<name>` — this choice is itself one of the
+    things the option branches should test.
+
+### P3. Test-suite federation plan
+
+- The current `tests/backends/` suite exercises every adapter together. Decide
+  how that splits: shared conformance test (a parametrized `BaseServerBackend`
+  contract test) that lives in core and can be re-used by each satellite, plus
+  adapter-specific tests that move with the adapter.
+- Provide a `tox`/CI matrix story for "core only" vs "core + one adapter" vs
+  "everything" so a contributor can run the slice they care about.
+
+## Options To Explore (one branch each)
+
+Each option below should be prototyped far enough to answer the **decision
+criteria** at the bottom. Suggested branch names are given; the requester will
+create/drive these branches.
+
+### Option A — Full multi-repo
+
+**Branch:** `claude/split-multi-repo-spike`
+
+- Core stays in this repo (possibly renamed to make the Django-merge intent
+  obvious, e.g. `django-prodserver-core` distribution while keeping the
+  `django_prodserver` import package).
+- Each adapter (or logical group of adapters) moves to its own repo + PyPI
+  package. Two sub-variants worth a quick look:
+  - **A1:** one repo per adapter (`django-prodserver-gunicorn`,
+    `django-prodserver-uvicorn`, ...). Maximal independence, maximal overhead.
+  - **A2:** one `django-prodserver-contrib` repo holding all the adapters that
+    *don't* get upstreamed, published either as one package with extras or as
+    several packages from one repo.
+- Adapters that are good upstream-PR candidates are documented as such
+  (django-tasks, django-q2, celery, arguably gunicorn/uvicorn integrations) and
+  the contrib repo carries them only until/unless upstream accepts them.
+- Deliverables on the branch: a script or `git filter-repo` recipe showing how an
+  adapter is extracted with history; a working `django-prodserver-gunicorn`
+  prototype installed from a sibling directory; updated docs describing the new
+  install story (`pip install django-prodserver django-prodserver-gunicorn`).
+
+**Pros:** clean "lift core into Django" story; each upstream owns the code that
+breaks when they release; users install only what they run.
+**Cons:** N repos × release cadence × CI matrices is heavy for a small/solo
+maintainer; cross-cutting `BaseServerBackend` changes need coordinated releases;
+discoverability drops (no more single `pip install django-prodserver[gunicorn]`).
+
+### Option B — Monorepo workspace of multiple publishable packages
+
+**Branch:** `claude/split-monorepo-workspace-spike`
+
+- Keep one repo, but restructure into a workspace (uv workspace or
+  PDM/hatch equivalent) with several independently-publishable packages:
+  ```
+  packages/
+    core/            -> django-prodserver-core   (the Django-merge candidate)
+    gunicorn/        -> django-prodserver-gunicorn
+    uvicorn/         -> django-prodserver-uvicorn
+    granian/         -> django-prodserver-granian
+    waitress/        -> django-prodserver-waitress
+    werkzeug/        -> django-prodserver-werkzeug
+    daphne/          -> django-prodserver-daphne
+    celery/          -> django-prodserver-celery
+    django-tasks/    -> django-prodserver-django-tasks
+    django-q2/       -> django-prodserver-django-q2
+    meta/            -> django-prodserver  (umbrella: depends on core + extras
+                                            re-export the per-adapter packages)
+  ```
+- Shared CI, shared lint/format config, one place to make `BaseServerBackend`
+  changes; each package still gets its own version + PyPI release + minimal
+  dependency closure.
+- The umbrella `django-prodserver` distribution keeps today's
+  `pip install django-prodserver[gunicorn]` working by mapping extras to the
+  per-adapter packages — no break for existing users.
+- "Lift core into Django" = copy `packages/core/` — still clean, without the
+  multi-repo tax.
+- Deliverables on the branch: working uv workspace; `django-prodserver-core`
+  builds with only `django` as a dep; at least two adapter packages build and
+  install; CI runs the federated test matrix from P3; docs updated.
+
+**Pros:** independent install/versioning + minimal deps per adapter, but one repo
+to maintain; easiest migration path; can still flip individual packages out to
+their own repos later (Option A) if an upstream bites.
+**Cons:** workspace tooling complexity; publishing many packages from one tag
+needs care (semantic-release config currently assumes one package); "merged into
+respective upstream repos" still requires a later move.
+
+### Option C — Single package, plugin-ready, no split (the "do less" option)
+
+**Branch:** `claude/split-plugin-only-spike`
+
+- Land only the Shared Prerequisite (entry points + boundary cleanup + test
+  federation), keep shipping one `django-prodserver` distribution with the
+  current extras.
+- The payoff: third parties (including the upstream projects, if they want) can
+  publish their *own* adapter packages against the documented entry-point
+  contract, without us splitting anything. The "core" is already importable on
+  its own; we just document the subset that would go to Django.
+- Deliverables on the branch: the P1–P3 work, a `docs/extending.md` describing
+  the backend plugin contract and entry-point group, and an example out-of-tree
+  adapter package in `examples/` to prove the contract works.
+
+**Pros:** smallest change, no release/CI multiplication, unblocks the ecosystem
+goal immediately, fully reversible.
+**Cons:** doesn't by itself achieve "core merged into Django" or "adapters in
+upstream repos" — it just makes both *possible* later. The big adapters
+(werkzeug, daphne, granian) still ship in the main distribution.
+
+## Affected / Reference Files
+
+Core (must remain dependency-free in every option):
+
+- `src/django_prodserver/__init__.py`
+- `src/django_prodserver/apps.py`
+- `src/django_prodserver/conf.py`
+- `src/django_prodserver/utils.py`
+- `src/django_prodserver/backends/__init__.py`
+- `src/django_prodserver/backends/base.py`
+- `src/django_prodserver/backends/_runserver_base.py`
+- `src/django_prodserver/backends/django_runserver.py` *(only zero-extra-dep adapter; candidate to ship with core)*
+- `src/django_prodserver/management/__init__.py`
+- `src/django_prodserver/management/commands/__init__.py`
+- `src/django_prodserver/management/commands/server.py`
+- `src/django_prodserver/management/commands/prodserver.py`
+- `src/django_prodserver/management/commands/devserver.py`
+- `src/django_prodserver/migrations/__init__.py`
+
+Adapters to extract / make pluggable:
+
+- `src/django_prodserver/backends/gunicorn.py`
+- `src/django_prodserver/backends/uvicorn.py`
+- `src/django_prodserver/backends/granian.py`
+- `src/django_prodserver/backends/waitress.py`
+- `src/django_prodserver/backends/werkzeug.py`
+- `src/django_prodserver/backends/daphne.py`
+- `src/django_prodserver/backends/celery.py`
+- `src/django_prodserver/backends/django_tasks.py`
+- `src/django_prodserver/backends/django_q2.py`
+
+Packaging / tooling to touch:
+
+- `pyproject.toml` (`[project.optional-dependencies]`, `[project.entry-points...]`,
+  `[tool.semantic_release]` — currently single-package), `uv.lock`, `tox.ini`,
+  `.github/` CI workflows, `docs/` (install + extending pages), `setup.py`.
+
+Tests:
+
+- `tests/backends/*` (federate per P3), `tests/test_server_command.py`,
+  `tests/test_conf.py`, `tests/test_utils.py`.
+
+## Decision Criteria (what each branch must let us judge)
+
+1. **Install ergonomics:** how many `pip install ...` lines does a typical user
+   need, and is the error message good when an adapter dep is missing?
+2. **Maintainer overhead:** number of release pipelines, CI jobs, and changelogs;
+   does `semantic-release` still work, or does it need replacing?
+3. **Django-merge readiness:** can the core be built/tested/shipped with only
+   `django` as a dependency, and is the public surface (commands + setting +
+   `BaseServerBackend`) cleanly isolated?
+4. **Upstream-PR viability:** for django-tasks, django-q2, celery — what exactly
+   would a PR to those repos contain, and does the adapter need anything from the
+   core beyond `BaseServerBackend`?
+5. **Back-compat:** does an existing project with `PRODUCTION_PROCESSES` pointing
+   at `django_prodserver.backends.gunicorn.GunicornServer` and
+   `pip install django-prodserver[gunicorn]` keep working with no changes?
+6. **Reversibility:** how hard is it to undo / re-merge if the experiment fails?
+
+## Recommendation (to be confirmed after the spikes)
+
+Start by landing the **Shared Prerequisite** (which is Option C in full). Then
+prototype **Option B (monorepo workspace)** as the primary candidate — it
+delivers the per-adapter install/versioning win and the "core is liftable into
+Django" story with the least disruption, while keeping the door open to Option A
+on a per-adapter basis whenever an upstream project agrees to host the adapter.
+Treat **Option A** as the long-term end state for individual adapters, not a
+big-bang migration.
+
+## Success Criteria
+
+- A base branch exists with entry-point discovery + boundary cleanup + a
+  federated test plan, with no breaking change to `PRODUCTION_PROCESSES` and all
+  existing tests green.
+- Three exploration branches exist (A, B, C), each with enough working code to
+  answer the decision criteria, plus a short `FINDINGS.md` on each branch.
+- A written comparison (this spec updated, or a follow-up doc) recommending one
+  option, with explicit answers to the six decision criteria.
+- The core package's dependency closure is demonstrably just `django` in
+  whichever option(s) implement a separate core.
+- Docs describe the chosen install story and the backend plugin contract.
+
+## Risks & Mitigations
+
+- **Release tooling:** `semantic_release` config in `pyproject.toml` assumes one
+  package; multi-package publishing needs new config or a different tool.
+  *Mitigation:* spike this explicitly on the Option B branch before committing.
+- **Discoverability regression:** users currently find everything via one
+  package + extras. *Mitigation:* keep an umbrella `django-prodserver`
+  distribution that pulls adapters via extras (Options A2 and B).
+- **History loss on extraction:** *Mitigation:* use `git filter-repo` (document
+  the recipe on the Option A branch) rather than fresh repos.
+- **Upstreams say no:** gunicorn/uvicorn/celery may not want a Django-specific
+  adapter. *Mitigation:* the contrib repo / per-adapter packages are the fallback
+  home; nothing depends on upstream acceptance.
+- **Namespace package pitfalls:** PEP 420 namespace packages (`django_prodserver.contrib.*`)
+  can interact badly with some tooling. *Mitigation:* test both the namespace and
+  the flat `django_prodserver_<name>` layouts on the option branches and pick the
+  one that "just works".

--- a/agent-os/specs/2026-05-19-entrypoint-foundation/planning/raw-idea.md
+++ b/agent-os/specs/2026-05-19-entrypoint-foundation/planning/raw-idea.md
@@ -1,0 +1,29 @@
+# Raw Idea
+
+> Captured from conversation on 2026-05-19.
+
+This is the **Phase 0** prerequisite carved out of the parent spec
+`2026-05-11-split-package-into-multiple-repos`. The parent spec evaluates how to
+split django-prodserver across multiple packages/repos; Phase 0 is the
+non-breaking foundation that has to land *before* any split spike begins:
+
+> "Also by the looks of it, we should just do option C as a prerequisite anyway.
+> Um or at least make a plan for option C as a prerequisite before anything
+> else."
+
+Phase 0 delivers:
+
+1. `importlib.metadata` entry-point–based backend discovery (closes
+   [#71](https://github.com/nanorepublica/django-prodserver/issues/71)) so
+   external packages can register backends without end-user setup.
+2. Package-boundary cleanup that makes the core importable with only `django`
+   installed (no `gunicorn`/`uvicorn`/etc. needed to import
+   `django_prodserver`).
+3. A federated test-suite layout so the per-adapter tests can later move with
+   the adapter when a split happens.
+4. Public docs of the plugin contract, plus a small example out-of-tree adapter
+   that exercises it in CI.
+
+It is intentionally **non-breaking**: today's `PRODUCTION_PROCESSES` dotted-path
+backends and `pip install django-prodserver[gunicorn]` install command must keep
+working unchanged.

--- a/agent-os/specs/2026-05-19-entrypoint-foundation/spec.md
+++ b/agent-os/specs/2026-05-19-entrypoint-foundation/spec.md
@@ -1,0 +1,330 @@
+# Specification: Backend Entry-Point Foundation (Phase 0)
+
+## Status
+
+Implementation spec. This is **Phase 0** of the parent spec
+[`2026-05-11-split-package-into-multiple-repos`](../2026-05-11-split-package-into-multiple-repos/spec.md)
+— a hard prerequisite that lands on `main` before any package-split spike
+begins. It is also independently shippable: even if no further split ever
+happens, this work closes [#71](https://github.com/nanorepublica/django-prodserver/issues/71)
+on its own.
+
+## Related Issues
+
+- [#71](https://github.com/nanorepublica/django-prodserver/issues/71) —
+  "Entrypoint support for backends" (primary; closed by this spec).
+- [#98](https://github.com/nanorepublica/django-prodserver/issues/98) —
+  "Splitting out the backends and the core API" (parent; unblocked by this spec
+  but not closed).
+
+## Goal
+
+Make `django_prodserver` importable, configurable, and testable as if it were
+already two layers — a dependency-free core and a set of pluggable adapters —
+**without actually moving any code between distributions**. By the end of
+Phase 0:
+
+1. Backends are discoverable via `importlib.metadata` entry points under the
+   group `django_prodserver.backends`, in addition to the existing dotted-path
+   `BACKEND = "..."` configuration.
+2. Installing `django-prodserver` with **no** extras (`pip install django-prodserver`)
+   leaves the package fully importable — no `ImportError` from any module under
+   `django_prodserver/` at import time.
+3. The full backend test matrix can be run as: "core only" (no extras), "core +
+   one adapter" (one extra installed), or "everything" (current behaviour).
+4. The plugin contract is documented, and an example out-of-tree adapter under
+   `examples/` proves the contract works end-to-end.
+
+## Non-Goals / Out of Scope
+
+- **Moving any adapter code out of `src/django_prodserver/backends/` into a
+  separate distribution.** That is parent-spec work (Option A / Option B).
+- **Changing what `pip install django-prodserver[gunicorn]` resolves to.** The
+  extras keep depending on `gunicorn` directly today; they will switch to
+  satellite packages in a later phase.
+- **Breaking any public API.** Every existing `PRODUCTION_PROCESSES`
+  configuration in the wild must keep working without edits — dotted-path
+  `BACKEND` strings, the `APP` key, every adapter's `ARGS` schema.
+- **Renaming management commands** (covered by #63 / #64).
+- **Touching `semantic_release` config** for multi-package publishing (parent
+  spec).
+
+## Background
+
+Today, `PRODUCTION_PROCESSES["<name>"]["BACKEND"]` is a dotted path that
+`server.py` resolves with `django.utils.module_loading.import_string`. That works,
+but it has two problems for the parent-spec direction:
+
+1. **No way for an external package to advertise a backend.** If Chancy
+   (#71's example) wanted to ship a `ChancyWorker` adapter, a user would have
+   to know the exact dotted path to put in their settings. There is no
+   registry, no `--list-backends`, no friendly error when the dep is missing.
+2. **Importing `django_prodserver.backends.gunicorn`** *currently* imports
+   `gunicorn` at module top level. So does `uvicorn.py` (`import uvicorn.main`)
+   and `waitress.py` (`import waitress.runner`). That means an introspection
+   tool, a docs builder, or a test runner with `gunicorn` uninstalled can't
+   even *enumerate* the available backends without `ImportError`. This blocks
+   "core is liftable into Django" — the core must not transitively reference
+   third-party servers at import time.
+
+The other adapters are already mostly clean:
+
+- `celery.py`: only imports `django.utils.module_loading.import_string` at
+  top; the Celery app is resolved at runtime.
+- `django_tasks.py`: only imports `django.core.management`; the django-tasks
+  worker is invoked via `call_command("db_worker")`.
+- `django_q2.py`: only imports `django.*` at top; `import django_q` is inside
+  `__init__` with `ImproperlyConfigured` raised on failure (the pattern we
+  want).
+- `granian.py`, `daphne.py`, `werkzeug.py`: only import `django` and stdlib at
+  top per current inspection — to be verified during P2.
+
+## Approach
+
+### P1 — Backend registry & entry-point discovery
+
+**New module: `src/django_prodserver/backends/registry.py`**
+
+A small, lazy registry with these responsibilities:
+
+- Discover entry points in the group `django_prodserver.backends` on first use,
+  using `importlib.metadata.entry_points(group="django_prodserver.backends")`.
+  Cache the result.
+- Provide `resolve(name_or_path: str) -> type[BaseServerBackend]`:
+  - If `name_or_path` matches a registered short name, load it (which may raise
+    `ModuleNotFoundError` if the adapter's third-party dep is missing — that
+    error is caught and re-raised as a `BackendDependencyMissing` with a
+    `pip install ...` hint).
+  - Otherwise, fall back to `import_string(name_or_path)` for back-compat with
+    today's dotted-path configs.
+- Provide `iter_registered() -> Iterable[BackendInfo]` where `BackendInfo`
+  exposes name, dotted path, distribution name, and `installed: bool`
+  (probed by attempting `entry_point.load()` and catching `ImportError`).
+
+**Update `server.py:99`:**
+
+```python
+# before
+backend_class = import_string(server_backend)
+
+# after
+from ..backends.registry import resolve_backend
+backend_class = resolve_backend(server_backend)
+```
+
+**Built-in registration:** in `src/django_prodserver/pyproject.toml`'s
+`[project.entry-points."django_prodserver.backends"]`, register each in-tree
+adapter under a stable short name:
+
+```toml
+[project.entry-points."django_prodserver.backends"]
+gunicorn      = "django_prodserver.backends.gunicorn:GunicornServer"
+uvicorn       = "django_prodserver.backends.uvicorn:UvicornServer"
+uvicorn-wsgi  = "django_prodserver.backends.uvicorn:UvicornWSGIServer"
+granian-asgi  = "django_prodserver.backends.granian:GranianASGIServer"
+granian-wsgi  = "django_prodserver.backends.granian:GranianWSGIServer"
+waitress      = "django_prodserver.backends.waitress:WaitressServer"
+werkzeug      = "django_prodserver.backends.werkzeug:WerkzeugRunserver"
+daphne        = "django_prodserver.backends.daphne:DaphneRunserver"
+django-runserver = "django_prodserver.backends.django_runserver:DjangoRunserver"
+celery-worker = "django_prodserver.backends.celery:CeleryWorker"
+celery-beat   = "django_prodserver.backends.celery:CeleryBeat"
+django-tasks  = "django_prodserver.backends.django_tasks:DjangoTasksWorker"
+django-q2    = "django_prodserver.backends.django_q2:DjangoQ2Worker"
+```
+
+(Final names to be decided in T1 — listed here as the working proposal.)
+
+**New CLI affordance:** add `server --list-backends` that prints registered
+backends with their dotted path and "installed" status. Keep `server --list`
+as it is (lists *configured processes*).
+
+**New error type: `BackendDependencyMissing`** subclassing `CommandError`. When
+a registered backend's third-party module is missing, surface:
+
+```
+BackendDependencyMissing: backend 'gunicorn' requires the 'gunicorn' package.
+  Install it with: pip install django-prodserver[gunicorn]
+```
+
+### P2 — Package-boundary cleanup
+
+**Make all top-level adapter imports lazy.** Move third-party imports inside
+`start_server` / `__init__` / `prep_server_args` so importing the adapter
+module no longer requires the dep to be installed. Specifically:
+
+- `gunicorn.py`: move `from gunicorn.app.wsgiapp import WSGIApplication` inside
+  the `DjangoApplication` class body or `start_server`.
+- `uvicorn.py`: move `import uvicorn.main` inside `start_server`.
+- `waitress.py`: move `import waitress.runner` inside `start_server`.
+- `granian.py`, `daphne.py`, `werkzeug.py`: audit; move any third-party top-level
+  imports inside methods as needed (current read suggests they're already OK).
+
+**Add a core-import guard test:**
+
+```python
+# tests/test_core_imports.py
+def test_core_imports_without_third_party():
+    """Importing django_prodserver with no adapters installed must not raise."""
+    # Run as a subprocess with a constrained sys.path / PYTHONPATH-blocked
+    # third-party modules. Asserts no ImportError when importing every module
+    # under django_prodserver.backends.* including the adapter modules.
+```
+
+This is the regression lock that keeps P2 from regressing as new backends are
+added.
+
+**Decide on the distribution/import-name convention for future satellites.**
+This decision is captured in `docs/extending.md` (P4) so future satellites are
+consistent. The proposed default:
+
+- Distribution: `django-prodserver-<name>` (e.g. `django-prodserver-gunicorn`).
+- Import package: flat `django_prodserver_<name>` rather than a PEP 420
+  namespace package, to dodge namespace-package tooling pitfalls. Final pick is
+  validated by the example adapter in P4.
+
+### P3 — Test-suite federation
+
+The current `tests/backends/test_<adapter>.py` files run against the
+single installed `django-prodserver` distribution. To support both today's
+"all extras installed" CI and tomorrow's "core only" / "one adapter installed"
+CI, restructure as follows:
+
+- **`tests/backends/conftest.py`** gains a `parametrize_backends` fixture that
+  yields each registered backend class. Tests that exercise the
+  `BaseServerBackend` *contract* (arg formatting, lazy import behaviour,
+  `BackendDependencyMissing` on missing dep) use this.
+- **`tests/backends/test_contract.py`** (new): the shared conformance test.
+  Asserts every registered backend can be `resolve()`d by its short name and
+  by its dotted path, instantiated with an empty `ARGS`, and that
+  `prep_server_args()` returns a list. Skips backends whose third-party dep is
+  not importable.
+- **Per-adapter tests stay where they are** but each gets a top-of-file
+  `pytest.importorskip("<dep>")` so the file is skipped wholesale when the
+  adapter's dep isn't installed.
+- **CI matrix** (`.github/workflows/`): add jobs `core-only` (extras=none),
+  `gunicorn-only` (extras=[gunicorn]), and keep the existing `all` job. The
+  core-only job runs `test_core_imports.py` + `test_contract.py` + every other
+  test file that doesn't depend on an adapter.
+
+### P4 — Plugin contract documentation + example adapter
+
+**`docs/extending.md`** (new):
+
+- The `django_prodserver.backends` entry-point group: how to register, naming
+  conventions, what the entry-point target must be (a `BaseServerBackend`
+  subclass).
+- `BaseServerBackend` API reference: `__init__(**server_args)`,
+  `start_server(*args)`, `prep_server_args() -> list[str]`,
+  `_format_server_args_from_dict()` (already public-ish in `base.py`).
+- The satellite-package convention chosen in P2.
+- Worked example: code listing for the example adapter below.
+
+**`examples/django-prodserver-echo/`** (new): the smallest possible adapter
+that registers via entry points.
+
+- Its own `pyproject.toml` with `[project.entry-points."django_prodserver.backends"]`
+  pointing at an `EchoServer` class.
+- `EchoServer.start_server` just prints its args and exits — proves the wiring
+  end-to-end with zero external dependencies.
+- A CI step `pip install -e examples/django-prodserver-echo` followed by a
+  pytest run that confirms `server echo` works and shows up under
+  `server --list-backends`.
+
+## Affected Files
+
+**New files:**
+
+- `src/django_prodserver/backends/registry.py`
+- `tests/test_core_imports.py`
+- `tests/backends/test_contract.py`
+- `docs/extending.md`
+- `examples/django-prodserver-echo/pyproject.toml`
+- `examples/django-prodserver-echo/src/django_prodserver_echo/__init__.py`
+- `examples/django-prodserver-echo/tests/test_echo.py`
+
+**Modified files:**
+
+- `src/django_prodserver/backends/__init__.py` — re-export
+  `resolve_backend`, `BackendDependencyMissing` (optional).
+- `src/django_prodserver/backends/gunicorn.py` — lazy import.
+- `src/django_prodserver/backends/uvicorn.py` — lazy import.
+- `src/django_prodserver/backends/waitress.py` — lazy import (if needed).
+- `src/django_prodserver/backends/granian.py` — audit, lazy-fy if needed.
+- `src/django_prodserver/backends/daphne.py` — audit, lazy-fy if needed.
+- `src/django_prodserver/backends/werkzeug.py` — audit, lazy-fy if needed.
+- `src/django_prodserver/management/commands/server.py` — call
+  `resolve_backend`; add `--list-backends`.
+- `src/django_prodserver/management/commands/devserver.py` — same registry
+  hookup if it does its own resolution (verify in T0).
+- `pyproject.toml` — add `[project.entry-points."django_prodserver.backends"]`.
+- `tests/backends/conftest.py` (may not exist yet) — add
+  `parametrize_backends` fixture.
+- `tests/backends/test_*.py` — add `pytest.importorskip` at top of each
+  adapter-specific test file.
+- `.github/workflows/ci.yml` (or equivalent) — add `core-only` and
+  `gunicorn-only` matrix jobs.
+- `docs/index.md` — link `extending.md` into the TOC.
+- `tox.ini` — add envs matching the new CI matrix.
+
+## Decision Points (resolve during implementation)
+
+1. **Entry-point names:** the table above is a proposal. Confirm before
+   landing — names go on PyPI metadata and are hard to change later.
+2. **`--list-backends` output format:** plain text vs. tabular. Lean plain text
+   to match the existing `--list`.
+3. **`BackendDependencyMissing`:** subclass `CommandError` (current
+   recommendation) or a new `ImproperlyConfigured`-style exception? The former
+   keeps the existing `server.py` error-formatting path working unchanged.
+4. **Whether to also register `prodserver`/`devserver` short-name resolution**
+   or only `server`. The aliases share `Command.start_server`, so the answer
+   is "automatically yes" — but verify.
+5. **Final naming of the flat-vs-namespace satellite import convention.** Pick
+   one (recommendation: flat `django_prodserver_<name>`) and document it.
+
+## Success Criteria
+
+- `pip install django-prodserver` (no extras) installs cleanly and:
+  - `python -c "import django_prodserver.backends.gunicorn"` does not raise.
+  - `python -c "import django_prodserver.backends.uvicorn"` does not raise.
+  - `python -c "import django_prodserver.backends.waitress"` does not raise.
+- `python manage.py server --list-backends` lists all 13 in-tree backends with
+  correct "installed" status given the extras configured.
+- An existing project with
+  `PRODUCTION_PROCESSES = {"web": {"BACKEND": "django_prodserver.backends.gunicorn.GunicornServer", "ARGS": {"bind": "0.0.0.0:8000"}}}`
+  starts unchanged.
+- The same project, written as
+  `PRODUCTION_PROCESSES = {"web": {"BACKEND": "gunicorn", "ARGS": {"bind": "0.0.0.0:8000"}}}`,
+  also starts (new short-name form).
+- A user with no `gunicorn` installed who runs the gunicorn config gets the
+  friendly `BackendDependencyMissing` error, not a raw `ModuleNotFoundError`.
+- CI `core-only` job passes (all tests not requiring an adapter), proving the
+  core import surface is clean.
+- `pip install -e examples/django-prodserver-echo && manage.py server echo`
+  works in CI without modifying `django-prodserver` itself.
+- `docs/extending.md` is published in the doc site TOC.
+- All existing tests still pass.
+- #71 can be closed with a link to the released version.
+
+## Risks & Mitigations
+
+- **Lazy imports break import-time class-construction patterns.** E.g.
+  `gunicorn.py` defines `class DjangoApplication(WSGIApplication):` at module
+  top, which requires `WSGIApplication` at import time. *Mitigation:* refactor
+  to construct `DjangoApplication` inside `start_server` (it's only used there
+  anyway), or keep the class body but wrap the import in a `TYPE_CHECKING`
+  guard plus a runtime `import_string` inside `__init__`.
+- **Entry-point discovery cost.** `importlib.metadata.entry_points()` walks
+  installed dists; it's cheap (~ms) but not free. *Mitigation:* cache the
+  registry on first access; never call inside hot paths.
+- **`pytest.importorskip` makes coverage misleading** for core-only CI runs.
+  *Mitigation:* surface a "tests skipped due to missing optional deps" summary
+  line; rely on the `all` CI job for full coverage measurement.
+- **PEP 420 namespace pitfalls** for future satellites. *Mitigation:* the
+  example adapter uses the flat layout this spec recommends; namespace layout
+  can be revisited in the parent-spec spikes.
+- **Short-name collisions** between in-tree backends and a satellite registering
+  the same name. *Mitigation:* `resolve_backend` documents that the *first*
+  registered entry point wins (or raises on collision — to be chosen in T1);
+  in-tree backend names are namespaced loosely (`celery-worker`, not `worker`)
+  to lower the collision surface.

--- a/agent-os/specs/2026-05-19-entrypoint-foundation/tasks.md
+++ b/agent-os/specs/2026-05-19-entrypoint-foundation/tasks.md
@@ -1,0 +1,312 @@
+# Task Breakdown: Backend Entry-Point Foundation (Phase 0)
+
+## Overview
+
+Total: 6 task groups, ~35 sub-tasks.
+
+This implements Phase 0 of the parent spec
+[`2026-05-11-split-package-into-multiple-repos`](../2026-05-11-split-package-into-multiple-repos/spec.md).
+The end state is: `django_prodserver` is importable with no third-party
+extras installed; backends are discoverable via `importlib.metadata` entry
+points (closes [#71](https://github.com/nanorepublica/django-prodserver/issues/71))
+while existing dotted-path configs keep working; the plugin contract is
+documented; CI exercises a "core only" matrix slice.
+
+**Target branch for implementation:** `claude/prodserver-entrypoint-foundation`
+(separate from the branch this spec lives on).
+
+---
+
+## Task List
+
+### Task Group 0: Audit & Decisions
+
+**Dependencies:** none.
+
+- [ ] 0.0 Resolve decision points before writing code
+  - [ ] 0.1 Confirm final entry-point short-name table (see spec §P1).
+    Document the chosen names in `docs/extending.md` (T4.1).
+  - [ ] 0.2 Audit `granian.py`, `daphne.py`, `werkzeug.py` for any third-party
+    top-level imports (`import granian`, `import daphne`, `import werkzeug.*`).
+    Record findings in the PR description so reviewers don't re-check.
+  - [ ] 0.3 Verify `devserver` and `prodserver` commands route through the same
+    backend resolution path as `server` (they share `Command.start_server` per
+    current read — confirm).
+  - [ ] 0.4 Choose `BackendDependencyMissing` parent class
+    (recommendation: subclass of `django.core.management.CommandError`).
+  - [ ] 0.5 Choose short-name collision policy: first-wins vs. raise. Document
+    in `extending.md`.
+
+**Acceptance Criteria:** decisions recorded in the spec's "Decision Points"
+section (edit in place) or in `extending.md`. No code changes yet.
+
+---
+
+### Task Group 1: Backend Registry & Entry-Point Discovery (P1)
+
+**Dependencies:** Task Group 0.
+
+- [ ] 1.0 Build the backend registry
+  - [ ] 1.1 Write tests for `registry.resolve_backend` covering:
+    - short-name resolution to an in-tree backend class
+    - dotted-path back-compat resolution (existing
+      `django_prodserver.backends.gunicorn.GunicornServer` path)
+    - `BackendDependencyMissing` when a registered short-name's underlying
+      module is missing (simulate via `monkeypatch` of `sys.modules`)
+    - unknown name → `CommandError`-compatible exception with a helpful
+      message listing registered names
+    - collision behaviour matching the policy chosen in T0.5
+  - [ ] 1.2 Create `src/django_prodserver/backends/registry.py` with:
+    - `BackendDependencyMissing` exception (subclass per T0.4)
+    - `BackendInfo` dataclass (`name`, `dotted_path`, `distribution`,
+      `installed`)
+    - `resolve_backend(name_or_path: str) -> type[BaseServerBackend]`
+    - `iter_registered() -> Iterable[BackendInfo]`
+    - Internal cached `_load_entry_points()` that calls
+      `importlib.metadata.entry_points(group="django_prodserver.backends")`
+  - [ ] 1.3 Optionally re-export `resolve_backend` and
+    `BackendDependencyMissing` from `backends/__init__.py` (public surface).
+  - [ ] 1.4 Update `src/django_prodserver/management/commands/server.py:99`
+    to call `resolve_backend(server_backend)` instead of
+    `import_string(server_backend)`. Catch `BackendDependencyMissing` and
+    re-raise as `CommandError` with the friendly message.
+  - [ ] 1.5 Add `--list-backends` to `server` command. Output format: one
+    backend per line, `<short-name>  <dotted-path>  [installed|missing]`.
+    Update `run_from_argv` to short-circuit when the flag is set, mirroring
+    the existing `--list` handling.
+  - [ ] 1.6 Register all in-tree adapters in `pyproject.toml` under
+    `[project.entry-points."django_prodserver.backends"]` using the names
+    confirmed in T0.1.
+  - [ ] 1.7 Run the registry tests; all pass.
+
+**Acceptance Criteria:**
+
+- `from django_prodserver.backends.registry import resolve_backend` works.
+- `PRODUCTION_PROCESSES["web"]["BACKEND"] = "gunicorn"` resolves to
+  `GunicornServer` (new behaviour).
+- `PRODUCTION_PROCESSES["web"]["BACKEND"] = "django_prodserver.backends.gunicorn.GunicornServer"`
+  still resolves (back-compat).
+- `manage.py server --list-backends` prints all 13 in-tree backends.
+- Missing-dep case produces `BackendDependencyMissing` with `pip install` hint.
+
+---
+
+### Task Group 2: Lazy-Import Refactor of Adapters (P2)
+
+**Dependencies:** Task Group 1.
+
+- [ ] 2.0 Make adapter modules importable with their third-party dep missing
+  - [ ] 2.1 Write `tests/test_core_imports.py`:
+    - Subprocess-based test that runs Python with each third-party dep
+      blocked (e.g. `sys.modules["gunicorn"] = None` or a fake meta-finder
+      that raises `ImportError` for `gunicorn`, `uvicorn`, `waitress`,
+      `granian`, `daphne`, `werkzeug`, `celery`, `django_tasks`, `django_q`).
+    - For each adapter module, attempt `importlib.import_module(...)` and
+      assert no exception.
+    - Run the test now — it should **fail** for `gunicorn.py`, `uvicorn.py`,
+      `waitress.py` (and any others surfaced in T0.2). This proves the test
+      bites; subsequent commits make it pass.
+  - [ ] 2.2 Refactor `src/django_prodserver/backends/gunicorn.py`:
+    - Remove module-level
+      `from gunicorn.app.wsgiapp import WSGIApplication`.
+    - Move the `DjangoApplication` class definition inside `start_server`
+      (it's only used there) **or** keep it at module scope but defer the
+      `WSGIApplication` base-class resolution via a `__init_subclass__` /
+      runtime `import_string` trick. Prefer the first approach for clarity.
+    - Verify existing gunicorn tests still pass with gunicorn installed.
+  - [ ] 2.3 Refactor `src/django_prodserver/backends/uvicorn.py`:
+    - Move `import uvicorn.main` from module top into `start_server`.
+  - [ ] 2.4 Refactor `src/django_prodserver/backends/waitress.py`:
+    - Move `import waitress.runner` from module top into `start_server`.
+  - [ ] 2.5 Lazy-fy `granian.py`, `daphne.py`, `werkzeug.py` if T0.2 found
+    any module-top third-party imports. Skip otherwise.
+  - [ ] 2.6 Re-run `tests/test_core_imports.py` with **all** extras
+    uninstalled in a clean venv. All assertions pass.
+  - [ ] 2.7 Re-run the full existing test suite with all extras installed
+    (current CI behaviour). All assertions pass — no regressions.
+
+**Acceptance Criteria:**
+
+- `python -c "import django_prodserver.backends.gunicorn"` succeeds in a
+  fresh venv with only `django` installed.
+- Same for every other adapter module.
+- All existing tests still green when extras are installed.
+
+---
+
+### Task Group 3: Test-Suite Federation (P3)
+
+**Dependencies:** Task Group 2.
+
+- [ ] 3.0 Restructure tests so they can run as core-only or all-extras
+  - [ ] 3.1 Create or extend `tests/backends/conftest.py` with a
+    `parametrize_backends` fixture that yields each registered backend's
+    `BackendInfo`. Backends whose dep is missing yield with
+    `installed=False`; tests can then `pytest.skip` if they need the dep.
+  - [ ] 3.2 Write `tests/backends/test_contract.py`:
+    - For each registered backend, assert `resolve_backend("<short>")`
+      returns the same class as `resolve_backend("<dotted.path>")`.
+    - For each backend whose dep is installed, assert it can be instantiated
+      with `ARGS={}` (skip if `installed=False`).
+    - For each backend, assert `prep_server_args()` returns a `list`.
+  - [ ] 3.3 Add `pytest.importorskip("<dep>")` (or equivalent skip marker) to
+    the top of each existing `tests/backends/test_<adapter>.py` so they're
+    silently skipped when the adapter's dep isn't installed:
+    - `test_gunicorn.py` → `pytest.importorskip("gunicorn")`
+    - `test_uvicorn.py` → `pytest.importorskip("uvicorn")`
+    - `test_waitress.py` → `pytest.importorskip("waitress")`
+    - `test_granian.py` → `pytest.importorskip("granian")`
+    - `test_daphne.py` → `pytest.importorskip("daphne")`
+    - `test_werkzeug.py` → `pytest.importorskip("werkzeug")`
+    - `test_celery.py` → `pytest.importorskip("celery")`
+    - `test_django_tasks.py` → `pytest.importorskip("django_tasks")`
+    - `test_django_q2.py` → `pytest.importorskip("django_q")`
+  - [ ] 3.4 Add `tox` envs for the new slices:
+    - `core` — only `dev` group, no adapter extras
+    - `gunicorn` — `dev` + `gunicorn` extra
+    - `all` — current behaviour
+  - [ ] 3.5 Verify locally:
+    - `tox -e core` passes; reports adapter-specific tests as skipped.
+    - `tox -e gunicorn` passes; runs core + gunicorn tests, skips others.
+    - `tox -e all` passes; no regressions.
+
+**Acceptance Criteria:**
+
+- `tox -e core` finishes green with adapter tests cleanly skipped.
+- `test_contract.py` runs against every registered backend.
+- No existing per-adapter test was removed; only the skip marker added.
+
+---
+
+### Task Group 4: Plugin Contract Docs & Example Adapter (P4)
+
+**Dependencies:** Task Groups 1–3.
+
+- [ ] 4.0 Document the plugin contract and ship a working example
+  - [ ] 4.1 Write `docs/extending.md`:
+    - "Registering a backend" — entry-point group, naming conventions, the
+      decision from T0.1 and T0.5 captured.
+    - "`BaseServerBackend` reference" — methods to implement / override,
+      with the cross-references to `base.py:BaseServerBackend`.
+    - "Satellite package convention" — distribution `django-prodserver-<name>`,
+      import `django_prodserver_<name>`, per T0 and the spec.
+    - "Example: writing an echo backend" — code-listing for the example below.
+    - Cross-link to backend reference pages in `docs/backends/`.
+  - [ ] 4.2 Add `docs/extending.md` to `docs/index.md` TOC.
+  - [ ] 4.3 Create `examples/django-prodserver-echo/`:
+    - `pyproject.toml` with:
+      ```toml
+      [project]
+      name = "django-prodserver-echo"
+      version = "0.0.1"
+      dependencies = ["django-prodserver"]
+
+      [project.entry-points."django_prodserver.backends"]
+      echo = "django_prodserver_echo:EchoServer"
+      ```
+    - `src/django_prodserver_echo/__init__.py` with an `EchoServer` subclass
+      of `BaseServerBackend` whose `start_server` prints its args and exits 0.
+    - `README.md` (very short).
+  - [ ] 4.4 Add a CI step that:
+    1. Installs the example: `pip install -e examples/django-prodserver-echo`
+    2. Runs `python manage.py server --list-backends` and greps for `echo`
+    3. Runs a smoke test that invokes the echo backend through
+       `Command.start_server` (or via subprocess if simpler).
+  - [ ] 4.5 Build the docs locally
+    (`cd docs && make html`) and verify `extending.md` renders, links resolve.
+
+**Acceptance Criteria:**
+
+- `docs/extending.md` builds and is reachable from the TOC.
+- The example adapter installs cleanly and shows up under
+  `server --list-backends` in CI.
+- The smoke test passes in CI.
+
+---
+
+### Task Group 5: CI Matrix & Release Note (P3 follow-up)
+
+**Dependencies:** Task Groups 1–4.
+
+- [ ] 5.0 Wire the new test slices into CI
+  - [ ] 5.1 Update `.github/workflows/ci.yml` (or wherever the test matrix
+    lives) to add:
+    - `core-only` job: install with no extras, run `tox -e core`.
+    - `gunicorn-only` job: install with `[gunicorn]`, run `tox -e gunicorn`.
+    - Keep the existing `all` job.
+    - Run the example-adapter smoke test from T4.4 in the `core-only` job.
+  - [ ] 5.2 Verify all jobs pass on a draft PR.
+  - [ ] 5.3 Update `CHANGELOG.md` with a Phase 0 entry referencing #71 and
+    noting that short-name `BACKEND` values are now supported in
+    `PRODUCTION_PROCESSES`.
+  - [ ] 5.4 Update `README.md` "Configuration" section to mention the short
+    names as a permitted form (with a note that dotted paths still work).
+
+**Acceptance Criteria:**
+
+- All three CI jobs green.
+- Changelog and README reflect the new resolution behaviour.
+
+---
+
+### Task Group 6: Final Verification & PR
+
+**Dependencies:** Task Groups 1–5.
+
+- [ ] 6.0 Verify Phase 0 success criteria end-to-end
+  - [ ] 6.1 Fresh venv:
+    `pip install -e .` (no extras) → all module imports succeed (run
+    `tests/test_core_imports.py`).
+  - [ ] 6.2 Fresh venv: `pip install -e .[gunicorn]` → existing dotted-path
+    config and new short-name config both start a server. Hit it with
+    `curl` to confirm it serves.
+  - [ ] 6.3 Fresh venv: `pip install -e .` → configure gunicorn backend →
+    confirm `BackendDependencyMissing` message is friendly and
+    actionable.
+  - [ ] 6.4 Fresh venv: `pip install -e . -e examples/django-prodserver-echo`
+    → `server --list-backends` lists `echo` as installed → `server echo`
+    runs.
+  - [ ] 6.5 Run the docs site locally and click through `extending.md` to
+    `backends/`, confirm cross-references work.
+  - [ ] 6.6 Open the PR with title `Phase 0: backend entry-point foundation
+    (closes #71)` and a description that:
+    - Links to this spec and the parent spec.
+    - Lists every behavioural change (short-name resolution, lazy imports,
+      `--list-backends`, `BackendDependencyMissing`).
+    - Calls out that no public API was removed.
+
+**Acceptance Criteria:**
+
+- Every bullet under Spec §"Success Criteria" is demonstrated.
+- PR description references #71 and the parent issue #98.
+
+---
+
+## Execution Order
+
+1. **Task Group 0** — decisions first, code never.
+2. **Task Group 1** — registry + entry-point wiring. Lands the user-visible
+   capability behind the boundary cleanup.
+3. **Task Group 2** — lazy imports. The regression test in T2.1 should be
+   written before T2.2–T2.5 so each refactor makes the test go from red to
+   green.
+4. **Task Group 3** — test federation. Comes after T2 because the
+   `pytest.importorskip` markers need T2 to be meaningful (otherwise the
+   import fires before pytest gets a chance to skip).
+5. **Task Group 4** — docs + example adapter. Validates the contract from
+   the outside.
+6. **Task Group 5** — CI wiring + changelog.
+7. **Task Group 6** — final verification and PR.
+
+## Success Metrics
+
+- **#71 closed** by the PR that lands this work.
+- **0 public-API removals.** Every existing `PRODUCTION_PROCESSES` config in
+  the wild keeps working.
+- **`tox -e core` green** with only `django` installed beyond the dev group.
+- **`server --list-backends`** lists 13 in-tree backends + the `echo`
+  example when installed.
+- **`docs/extending.md` published** and linked from the docs TOC.
+- **Parent spec unblocked:** the next branch (`claude/split-monorepo-workspace-spike`
+  or `claude/split-multi-repo-spike`) can fork from `main` and start moving
+  code with confidence that the seam is real.


### PR DESCRIPTION
## Description of change

This PR adds two specification documents that outline the strategic direction for restructuring django-prodserver:

1. **`2026-05-11-split-package-into-multiple-repos/spec.md`** — The parent specification that evaluates three structural options (Option A: full multi-repo, Option B: monorepo workspace, Option C: plugin-ready single package) for splitting django-prodserver into a dependency-free core and pluggable backend adapters. This enables the core to be a credible candidate for eventual inclusion in Django, while allowing each backend to be maintained independently or upstreamed into its respective server/worker project.

2. **`2026-05-19-entrypoint-foundation/spec.md`** and **`tasks.md`** — Phase 0, a hard prerequisite that lands before any split spike begins. Phase 0 delivers:
   - `importlib.metadata` entry-point–based backend discovery (closes #71) so external packages can register backends without end-user setup
   - Package-boundary cleanup making the core importable with only `django` installed
   - A federated test-suite layout for future adapter extraction
   - Public documentation of the plugin contract with a working example adapter

3. **Planning documents** (`raw-idea.md` files) capturing the initial conversation context for both specs.

These specifications are **exploratory and non-breaking**. They do not modify any source code, tests, or configuration — only add documentation to guide future implementation work. The parent spec will be prototyped on separate branches; Phase 0 is the foundation that merges to `main` first.

**Related issues:** #71 (entry-point support for backends), #98 (splitting out backends and core API)

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the [contributing guidelines](https://github.com/nanorepublica/django-prodserver/blob/main/CONTRIBUTING.md)
- [x] This pull request links relevant issues (#71, #98)
- [ ] There are new or updated unit tests validating the change — N/A (specification documents only)
- [x] Documentation has been updated to reflect this change
- [x] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

https://claude.ai/code/session_01E94jTQzAFmncvZYiQZouM1