### PR TITLE
Filter server/worker backends by type in management commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,8 @@ python manage.py worker worker
 Both commands read from the same `PRODUCTION_PROCESSES` setting; `server` only accepts
 server backends and `worker` only accepts worker backends. If you point one at the wrong
 kind of backend it will tell you which command to use instead. Run either command with
-`--list` to see the configured process names.
+`--list` to see its configured process names: `server --list` shows only server
+backends and `worker --list` shows only worker backends.
 
 > **Deprecated:** `python manage.py prodserver` continues to work as an alias but is deprecated and will be removed in django-prodserver 4.0.0. Use `python manage.py server` instead.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -19,7 +19,8 @@ python manage.py worker <process_name>
 Both commands read from the same `PRODUCTION_PROCESSES` setting. `server` only
 accepts server backends and `worker` only accepts worker backends; pointing one
 at the wrong kind of backend produces an error telling you which command to use.
-Pass `--list` to either command to print the configured process names.
+Pass `--list` to either command to print its configured process names; `server
+--list` shows only server backends and `worker --list` only worker backends.
 
 ```{deprecated} 3.0.0
 The `prodserver` command has been renamed to `server`. The old name continues

--- a/src/django_prodserver/management/base.py
+++ b/src/django_prodserver/management/base.py
@@ -39,7 +39,7 @@ class BaseProcessCommand(BaseCommand):
                 "Check the documentation to configure this setting correctly."
             ) from None
         try:
-            default = next(iter(choices))
+            default = next(iter(self._matching_process_names()))
         except StopIteration:
             raise CommandError(
                 f"No {self.process_label}s configured in the PRODUCTION_PROCESSES "
@@ -54,6 +54,51 @@ class BaseProcessCommand(BaseCommand):
             default=default,
         )
         parser.add_argument("--list", action="store_true")
+
+    def _matching_process_names(self) -> list[str]:
+        """
+        Return the configured process names runnable by this command.
+
+        Each configured backend is imported and classified as a server or
+        worker backend; names whose backend subclasses
+        :attr:`backend_base_class` are returned. A misconfigured or
+        unclassifiable backend raises :class:`CommandError` so the problem
+        surfaces instead of being silently hidden.
+        """
+        try:
+            processes = app_settings.PRODUCTION_PROCESSES.items()
+        except AttributeError:
+            raise CommandError(
+                "PRODUCTION_PROCESSES setting has been configured incorrectly.\n"
+                "Check the documentation to configure this setting correctly."
+            ) from None
+
+        matching = []
+        for process_name, process_config in processes:
+            try:
+                backend_path = process_config["BACKEND"]
+            except KeyError:
+                raise CommandError(
+                    f"Backend not configured for process named '{process_name}'"
+                ) from None
+            try:
+                backend_class = import_string(backend_path)
+            except ImportError as e:
+                raise CommandError(
+                    f"Backend '{backend_path}' configured for process named "
+                    f"'{process_name}' could not be imported: {e}"
+                ) from None
+            if not (
+                isinstance(backend_class, type)
+                and issubclass(backend_class, (BaseServerBackend, BaseWorkerBackend))
+            ):
+                raise CommandError(
+                    f"Backend '{backend_path}' configured for process named "
+                    f"'{process_name}' is not a server or worker backend."
+                )
+            if issubclass(backend_class, self.backend_base_class):
+                matching.append(process_name)
+        return matching
 
     def run_from_argv(self, argv: list[str]) -> None:
         """
@@ -149,7 +194,7 @@ class BaseProcessCommand(BaseCommand):
 
     def list_process_names(self) -> None:
         """Simple function to return a list of the configured processes."""
-        available = "\n ".join(app_settings.PRODUCTION_PROCESSES.keys())
+        available = "\n ".join(self._matching_process_names())
         self.stdout.write(
             self.style.SUCCESS(
                 f"Available {self.process_label} process names are:\n {available}"

--- a/tests/test_prodserver_command.py
+++ b/tests/test_prodserver_command.py
@@ -8,7 +8,7 @@ tests here verify that the deprecated alias still works AND emits a
 
 import warnings
 from io import StringIO
-from unittest.mock import Mock, patch
+from unittest.mock import patch
 
 from django.test import TestCase, override_settings
 
@@ -19,6 +19,7 @@ from django_prodserver.management.commands.prodserver import (
     Command as ProdServerCommand,
 )
 from django_prodserver.management.commands.server import Command as ServerCommand
+from tests.test_server_command import DUMMY_SERVER, _DummyServerBackend
 
 
 class TestProdserverDeprecation(TestCase):
@@ -36,13 +37,7 @@ class TestProdserverDeprecation(TestCase):
     def test_command_instance_creation(self):
         assert isinstance(self.command, ProdServerCommand)
 
-    @override_settings(
-        PRODUCTION_PROCESSES={
-            "web": {
-                "BACKEND": "django_prodserver.backends.servers.gunicorn.GunicornServer"
-            }
-        }
-    )
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
     def test_run_from_argv_emits_deprecation_warning(self):
         """Running `prodserver --list` must raise a DeprecationWarning."""
         with warnings.catch_warnings(record=True) as caught:
@@ -54,13 +49,7 @@ class TestProdserverDeprecation(TestCase):
         assert "prodserver" in str(deprecations[0].message)
         assert "server" in str(deprecations[0].message)
 
-    @override_settings(
-        PRODUCTION_PROCESSES={
-            "web": {
-                "BACKEND": "django_prodserver.backends.servers.gunicorn.GunicornServer"
-            }
-        }
-    )
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
     def test_run_from_argv_writes_warning_to_stderr(self):
         """The deprecation must also be visible to humans on stderr."""
         with warnings.catch_warnings():
@@ -70,27 +59,17 @@ class TestProdserverDeprecation(TestCase):
         assert "DeprecationWarning" in self.command.stderr.getvalue()
         assert "prodserver" in self.command.stderr.getvalue()
 
-    @override_settings(
-        PRODUCTION_PROCESSES={
-            "web": {
-                "BACKEND": "django_prodserver.backends.servers.gunicorn.GunicornServer"
-            }
-        }
-    )
-    @patch("django_prodserver.management.base.import_string")
-    def test_run_from_argv_still_starts_server(self, mock_import_string):
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
+    def test_run_from_argv_still_starts_server(self):
         """Despite the warning, the command must still start the server."""
-        mock_backend_class = Mock()
-        mock_backend_instance = Mock()
-        mock_backend_instance.prep_server_args.return_value = []
-        mock_backend_class.return_value = mock_backend_instance
-        mock_import_string.return_value = mock_backend_class
-
-        with warnings.catch_warnings():
+        with (
+            warnings.catch_warnings(),
+            patch.object(_DummyServerBackend, "start_server") as mock_start,
+        ):
             warnings.simplefilter("always")
             self.command.run_from_argv(["manage.py", "prodserver", "web"])
 
-        mock_backend_instance.start_server.assert_called_once()
+        mock_start.assert_called_once()
 
     def test_deprecation_message_mentions_removal_version(self):
         """The deprecation message must point users to `server` and 4.0.0."""

--- a/tests/test_server_command.py
+++ b/tests/test_server_command.py
@@ -3,14 +3,45 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from django.core.management import CommandError, call_command
-from django.core.management.base import SystemCheckError
+from django.core.management.base import OutputWrapper, SystemCheckError
 from django.test import TestCase, override_settings
 
+from django_prodserver.backends.base import (
+    BaseProcessBackend,
+    BaseServerBackend,
+    BaseWorkerBackend,
+)
 from django_prodserver.management.commands.devserver import Command as DevServerCommand
 from django_prodserver.management.commands.server import Command
 from django_prodserver.management.commands.server import (
     Command as ServerCommand,
 )
+
+
+class _DummyServerBackend(BaseServerBackend):
+    """An importable server backend used to exercise the server command."""
+
+    def start_server(self, *args: str) -> None:
+        """Start nothing; command tests patch this when they need to."""
+
+
+class _DummyWorkerBackend(BaseWorkerBackend):
+    """An importable worker backend used to exercise backend classification."""
+
+    def start_server(self, *args: str) -> None:  # pragma: no cover - never run
+        raise AssertionError("the server command must not start a worker backend")
+
+
+class _DummyBareBackend(BaseProcessBackend):
+    """A backend that is neither a server nor a worker backend."""
+
+    def start_server(self, *args: str) -> None:  # pragma: no cover - never run
+        raise AssertionError("a bare process backend is not runnable")
+
+
+DUMMY_SERVER = "tests.test_server_command._DummyServerBackend"
+DUMMY_WORKER = "tests.test_server_command._DummyWorkerBackend"
+DUMMY_BARE = "tests.test_server_command._DummyBareBackend"
 
 
 class TestServerCommand(TestCase):
@@ -53,19 +84,19 @@ class TestServerCommand(TestCase):
 
     @override_settings(
         PRODUCTION_PROCESSES={
-            "web-1": {"BACKEND": "test.backend.1"},
-            "web-2": {"BACKEND": "test.backend.2"},
-            "worker-1": {"BACKEND": "test.backend.3"},
+            "web-1": {"BACKEND": DUMMY_SERVER},
+            "web-2": {"BACKEND": DUMMY_SERVER},
+            "worker-1": {"BACKEND": DUMMY_WORKER},
         }
     )
     def test_multiple_server_configurations(self):
-        """Test handling of multiple server configurations."""
+        """`--list` shows server processes and omits worker processes."""
         self.command.run_from_argv(["manage.py", "server", "--list"])
 
         output = self.command.stdout.getvalue()
         assert "web-1" in output
         assert "web-2" in output
-        assert "worker-1" in output
+        assert "worker-1" not in output
 
     def test_command_error_handling(self):
         """Test various error conditions in commands."""
@@ -100,10 +131,8 @@ class TestServerCommand(TestCase):
 
     @override_settings(
         PRODUCTION_PROCESSES={
-            "web": {
-                "BACKEND": "django_prodserver.backends.servers.gunicorn.GunicornServer"
-            },
-            "worker": {"BACKEND": "django_prodserver.backends.celery.CeleryWorker"},
+            "web": {"BACKEND": DUMMY_SERVER},
+            "worker": {"BACKEND": DUMMY_WORKER},
         }
     )
     def test_add_arguments_with_choices(self):
@@ -126,34 +155,31 @@ class TestServerCommand(TestCase):
         assert args[0] == "--list"
         assert kwargs["action"] == "store_true"
 
-    @override_settings(PRODUCTION_PROCESSES={"test": {}})
-    def test_add_arguments_empty_choices(self):
-        """Test add_arguments with empty PRODUCTION_PROCESSES."""
+    @override_settings(PRODUCTION_PROCESSES={"test": {"BACKEND": DUMMY_SERVER}})
+    def test_add_arguments_single_process(self):
+        """Test add_arguments with a single configured process."""
         parser = MagicMock()
 
-        # Should not raise error even with empty choices
         self.command.add_arguments(parser)
 
         calls = parser.add_argument.call_args_list
         server_name_call = calls[0]
-        args, kwargs = server_name_call
+        _, kwargs = server_name_call
         assert list(kwargs["choices"]) == ["test"]
 
     @override_settings(
         PRODUCTION_PROCESSES={
-            "web": {
-                "BACKEND": "django_prodserver.backends.servers.gunicorn.GunicornServer"
-            },
-            "worker": {"BACKEND": "django_prodserver.backends.celery.CeleryWorker"},
+            "web": {"BACKEND": DUMMY_SERVER},
+            "worker": {"BACKEND": DUMMY_WORKER},
         }
     )
     def test_list_process_names(self):
-        """Test list_process_names method."""
+        """`list_process_names` shows servers and omits workers."""
         self.command.list_process_names()
 
         output = self.command.stdout.getvalue()
         assert "web" in output
-        assert "worker" in output
+        assert "worker" not in output
         assert "Available server process names are:" in output
 
     @override_settings(PRODUCTION_PROCESSES={})
@@ -246,6 +272,7 @@ class TestServerCommand(TestCase):
             ARGS={"bind": "0.0.0.0:8000"},
         )
 
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
     @patch("sys.exit")
     def test_run_from_argv_list_option(self, mock_exit):
         """Test run_from_argv with --list option."""
@@ -255,51 +282,40 @@ class TestServerCommand(TestCase):
             # Should return early and not call sys.exit
             mock_exit.assert_not_called()
 
-    @override_settings(
-        PRODUCTION_PROCESSES={
-            "web": {
-                "BACKEND": "django_prodserver.backends.servers.gunicorn.GunicornServer"
-            }
-        }
-    )
-    @patch("django_prodserver.management.base.import_string")
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
     @patch("sys.exit")
-    def test_run_from_argv_start_server(self, mock_exit, mock_import_string):
+    def test_run_from_argv_start_server(self, mock_exit):
         """Test run_from_argv starting a server."""
-        mock_backend_class = Mock()
-        mock_backend_instance = Mock()
-        mock_backend_instance.prep_server_args.return_value = []
-        mock_backend_class.return_value = mock_backend_instance
-        mock_import_string.return_value = mock_backend_class
+        with patch.object(_DummyServerBackend, "start_server") as mock_start:
+            self.command.run_from_argv(["manage.py", "server", "web"])
 
-        self.command.run_from_argv(["manage.py", "server", "web"])
-
-        mock_backend_instance.start_server.assert_called_once()
+        mock_start.assert_called_once()
         mock_exit.assert_not_called()
 
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
     @patch("sys.exit")
     def test_run_from_argv_command_error(self, mock_exit):
         """Test run_from_argv with CommandError."""
         with patch.object(self.command, "start_process") as mock_start:
             mock_start.side_effect = CommandError("Test error")
 
-            self.command.run_from_argv(["manage.py", "server", "nonexistent"])
+            self.command.run_from_argv(["manage.py", "server", "web"])
 
             mock_exit.assert_called_with(1)
 
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
     @patch("sys.exit")
     def test_run_from_argv_system_check_error(self, mock_exit):
         """Test run_from_argv with SystemCheckError."""
+        self.command.stderr = OutputWrapper(StringIO())
         with patch.object(self.command, "start_process") as mock_start:
-            mock_start.side_effect = lambda *x, **y: SystemCheckError(
-                "System check failed"
-            )
+            mock_start.side_effect = SystemCheckError("System check failed")
 
             self.command.run_from_argv(["manage.py", "server", "web"])
 
-            mock_exit.assert_called_with(2)
+            mock_exit.assert_called_with(1)
 
-    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": "test.backend"}})
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
     @patch("sys.exit")
     def test_run_from_argv_traceback_option(self, mock_exit):
         """Test run_from_argv with --traceback option."""
@@ -319,6 +335,7 @@ class TestServerCommand(TestCase):
             # Should not call sys.exit when traceback is requested
             mock_exit.assert_not_called()
 
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
     def test_called_from_command_line_attribute(self):
         """Test that _called_from_command_line is set correctly."""
         assert hasattr(self.command, "_called_from_command_line")
@@ -330,13 +347,9 @@ class TestServerCommand(TestCase):
 
     @override_settings(
         PRODUCTION_PROCESSES={
-            "web1": {
-                "BACKEND": "django_prodserver.backends.servers.gunicorn.GunicornServer"
-            },
-            "web2": {
-                "BACKEND": "django_prodserver.backends.servers.uvicorn.UvicornServer"
-            },
-            "worker": {"BACKEND": "django_prodserver.backends.celery.CeleryWorker"},
+            "web1": {"BACKEND": DUMMY_SERVER},
+            "web2": {"BACKEND": DUMMY_SERVER},
+            "worker": {"BACKEND": DUMMY_WORKER},
         }
     )
     def test_default_server_selection(self):
@@ -346,7 +359,7 @@ class TestServerCommand(TestCase):
 
         calls = parser.add_argument.call_args_list
         server_name_call = calls[0]
-        args, kwargs = server_name_call
+        _, kwargs = server_name_call
 
         # Should have a default value (first in choices)
         assert "default" in kwargs
@@ -375,6 +388,7 @@ class TestServerCommand(TestCase):
         output = self.command.stdout.getvalue()
         assert "Starting server named web" in output
 
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
     def test_server_name_argument_properties(self):
         """Test server_name argument properties."""
         parser = MagicMock()
@@ -487,3 +501,53 @@ class TestServerCommand(TestCase):
         assert "Configure your servers before running this command" in str(
             exc_info.value
         )
+
+    @override_settings(
+        PRODUCTION_PROCESSES={
+            "worker": {"BACKEND": DUMMY_WORKER},
+            "web": {"BACKEND": DUMMY_SERVER},
+        }
+    )
+    def test_default_skips_non_server_backends(self):
+        """The no-argument default is the first server backend, not a worker."""
+        parser = MagicMock()
+        self.command.add_arguments(parser)
+
+        _, kwargs = parser.add_argument.call_args_list[0]
+        assert kwargs["default"] == "web"
+
+    @override_settings(PRODUCTION_PROCESSES={"worker": {"BACKEND": DUMMY_WORKER}})
+    def test_add_arguments_no_server_backends(self):
+        """add_arguments fails when only worker backends are configured."""
+        with pytest.raises(CommandError) as exc_info:
+            self.command.add_arguments(MagicMock())
+
+        assert "No servers configured in the PRODUCTION_PROCESSES setting" in str(
+            exc_info.value
+        )
+
+    @override_settings(
+        PRODUCTION_PROCESSES={"web": {"BACKEND": "django_prodserver.missing.Backend"}}
+    )
+    def test_list_raises_on_unimportable_backend(self):
+        """A backend that cannot be imported surfaces as a CommandError."""
+        with pytest.raises(CommandError) as exc_info:
+            self.command.list_process_names()
+
+        assert "could not be imported" in str(exc_info.value)
+
+    @override_settings(PRODUCTION_PROCESSES={"web": {}})
+    def test_list_raises_on_missing_backend(self):
+        """A process configured without a BACKEND key surfaces as a CommandError."""
+        with pytest.raises(CommandError) as exc_info:
+            self.command.list_process_names()
+
+        assert "Backend not configured for process named 'web'" in str(exc_info.value)
+
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_BARE}})
+    def test_list_raises_on_non_process_backend(self):
+        """A backend that is neither a server nor a worker is rejected."""
+        with pytest.raises(CommandError) as exc_info:
+            self.command.list_process_names()
+
+        assert "is not a server or worker backend" in str(exc_info.value)

--- a/tests/test_worker_command.py
+++ b/tests/test_worker_command.py
@@ -80,13 +80,59 @@ class TestWorkerCommand(TestCase):
         }
     )
     def test_list_process_names(self):
-        """Test list_process_names method."""
+        """`list_process_names` shows workers and omits servers."""
         self.command.list_process_names()
 
         output = self.command.stdout.getvalue()
-        assert "web" in output
         assert "worker" in output
+        assert "web" not in output
         assert "Available worker process names are:" in output
+
+    @override_settings(
+        PRODUCTION_PROCESSES={
+            "web": {"BACKEND": DUMMY_SERVER},
+            "worker": {"BACKEND": DJANGO_TASKS_WORKER},
+        }
+    )
+    def test_default_skips_non_worker_backends(self):
+        """The no-argument default is the first worker backend, not a server."""
+        parser = MagicMock()
+        self.command.add_arguments(parser)
+
+        _, kwargs = parser.add_argument.call_args_list[0]
+        assert kwargs["default"] == "worker"
+
+    @override_settings(PRODUCTION_PROCESSES={"web": {"BACKEND": DUMMY_SERVER}})
+    def test_add_arguments_no_worker_backends(self):
+        """add_arguments fails when only server backends are configured."""
+        with pytest.raises(CommandError) as exc_info:
+            self.command.add_arguments(MagicMock())
+
+        assert "No workers configured in the PRODUCTION_PROCESSES setting" in str(
+            exc_info.value
+        )
+
+    @override_settings(
+        PRODUCTION_PROCESSES={
+            "worker": {"BACKEND": "django_prodserver.missing.Backend"}
+        }
+    )
+    def test_list_raises_on_unimportable_backend(self):
+        """A backend that cannot be imported surfaces as a CommandError."""
+        with pytest.raises(CommandError) as exc_info:
+            self.command.list_process_names()
+
+        assert "could not be imported" in str(exc_info.value)
+
+    @override_settings(PRODUCTION_PROCESSES={"worker": {}})
+    def test_list_raises_on_missing_backend(self):
+        """A process configured without a BACKEND key surfaces as a CommandError."""
+        with pytest.raises(CommandError) as exc_info:
+            self.command.list_process_names()
+
+        assert "Backend not configured for process named 'worker'" in str(
+            exc_info.value
+        )
 
     @override_settings(PRODUCTION_PROCESSES=ONE_WORKER)
     @patch("django.core.management.call_command")
@@ -133,24 +179,27 @@ class TestWorkerCommand(TestCase):
         assert "Backend not configured for worker named worker" in str(exc_info.value)
 
     @override_settings(PRODUCTION_PROCESSES=ONE_WORKER)
-    @patch("django_prodserver.management.base.import_string")
     @patch("sys.exit")
-    def test_run_from_argv_command_error(self, mock_exit, mock_import_string):
+    def test_run_from_argv_command_error(self, mock_exit):
         """Test run_from_argv converts CommandError to an exit code."""
-        mock_import_string.side_effect = CommandError("boom")
+        with patch.object(self.command, "start_process") as mock_start:
+            mock_start.side_effect = CommandError("boom")
 
-        self.command.run_from_argv(["manage.py", "worker", "worker"])
+            self.command.run_from_argv(["manage.py", "worker", "worker"])
 
         mock_exit.assert_called_with(1)
 
     @override_settings(PRODUCTION_PROCESSES=ONE_WORKER)
-    @patch("django_prodserver.management.base.import_string")
-    def test_run_from_argv_list_option(self, mock_import_string):
-        """Test run_from_argv with --list option short-circuits."""
-        with patch.object(self.command, "list_process_names") as mock_list:
+    def test_run_from_argv_list_option(self):
+        """Test run_from_argv with --list option lists without starting."""
+        with (
+            patch.object(self.command, "list_process_names") as mock_list,
+            patch.object(self.command, "start_process") as mock_start,
+        ):
             self.command.run_from_argv(["manage.py", "worker", "--list"])
-            mock_list.assert_called_once()
-        mock_import_string.assert_not_called()
+
+        mock_list.assert_called_once()
+        mock_start.assert_not_called()
 
     @override_settings(PRODUCTION_PROCESSES=ONE_WORKER)
     @patch("django_prodserver.management.base.import_string")


### PR DESCRIPTION
### Description of change

This change improves the `server` and `worker` management commands to properly classify and filter configured backends by their type (server vs. worker), ensuring each command only operates on the appropriate backend types.

**Current behavior:**
- The `--list` option shows all configured processes regardless of backend type
- Commands don't validate that backends are the correct type until runtime
- A misconfigured backend (missing BACKEND key, unimportable, or wrong type) fails silently or with unclear errors

**New behavior:**
- The `--list` option only shows processes with matching backend types (servers for `server` command, workers for `worker` command)
- The default process selection skips non-matching backend types
- Backend validation happens early with clear error messages for:
  - Missing BACKEND configuration
  - Unimportable backends
  - Backends that are neither server nor worker types
- Added test fixtures (`_DummyServerBackend`, `_DummyWorkerBackend`, `_DummyBareBackend`) to support comprehensive testing

**Implementation details:**
- Added `_matching_process_names()` method to `BaseProcessCommand` that imports and classifies each configured backend
- Updated `add_arguments()` to use `_matching_process_names()` for default selection
- Updated `list_process_names()` to use `_matching_process_names()` for filtering
- Replaced mock-heavy tests with concrete test backend implementations for better clarity and maintainability

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] This pull request follows the contributing guidelines
- [x] There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change

https://claude.ai/code/session_01SiXTXoqyxFnPKJxiPxVRvd